### PR TITLE
#101 - Home > Resolve UI bugs for display upcoming courses

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -11,7 +11,7 @@ class StaticPagesController < ApplicationController
     if current_user
       render :dashboard
     else
-      @workshops = Workshop.all
+      @workshops = Workshop.upcoming_courses
       render layout: 'home'
     end
   end

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -17,6 +17,9 @@ class Workshop < ActiveRecord::Base
 
   accepts_nested_attributes_for :workshop_sessions, allow_destroy: true, reject_if: proc { |att|  att[:session_start].blank? || att[:session_end].blank?}
 
+  # Upcoming courses for homepage
+  scope :upcoming_courses, lambda { where("start_date >= ?", Date.today).order(:start_date) }
+
   def eligibilities
     course.eligibilities
   end


### PR DESCRIPTION
1) List shows past workshops as well. It should show only upcoming(tomorrow or later) courses only.
2) Worshop are not sorted. It should sort by date(ascending)
